### PR TITLE
Get most viewed videos upload working

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,6 +1,11 @@
+import com.twitter.scrooge.ScroogeSBT
 import sbt._
 import Keys._
+import sbtassembly.Plugin._
+import sbtassembly.Plugin.AssemblyKeys._
+
 import com.typesafe.sbt.SbtScalariform.scalariformSettings
+import sbtassembly.Plugin.{PathList, MergeStrategy}
 
 object MostViewedVideoUploaderBuild extends Build {
 
@@ -12,6 +17,7 @@ object MostViewedVideoUploaderBuild extends Build {
   )
 
   val root = Project("most-viewed-video-uploader", file("."))
+    .settings(ScroogeSBT.newSettings: _*)
     .settings(
 
       libraryDependencies ++= Seq(
@@ -20,10 +26,24 @@ object MostViewedVideoUploaderBuild extends Build {
         "com.amazonaws" % "aws-java-sdk-kinesis" % "1.10.39",
         "com.squareup.okhttp" % "okhttp" % "2.5.0",
         "com.gu" %% "content-api-client" % "7.29",
+        "io.circe" %% "circe-generic" % "0.3.0",
+        "io.circe" %% "circe-parser" % "0.3.0",
+        "org.apache.thrift" % "libthrift" % "0.9.2",
+        "com.twitter" %% "scrooge-core" % "3.20.0",
+        "com.gu" %% "thrift-serializer" % "0.0.1",
         "org.scalatest" %% "scalatest" % "2.2.5" % "test"
       )
     )
     .settings(basicSettings)
     .settings(scalariformSettings)
+    .settings(assemblySettings: _*)
+    .settings(
+      mergeStrategy in assembly <<= (mergeStrategy in assembly) {
+        (old) => {
+          case PathList("com", "gu", "storypackage", _*) => MergeStrategy.first
+          case x => old(x)
+        }
+      }
+    )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "3.16.3")

--- a/src/main/scala/com/gu/contentapi/Config.scala
+++ b/src/main/scala/com/gu/contentapi/Config.scala
@@ -2,7 +2,6 @@ package com.gu.contentapi
 
 import java.util.Properties
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.s3.AmazonS3Client
 

--- a/src/main/scala/com/gu/contentapi/Config.scala
+++ b/src/main/scala/com/gu/contentapi/Config.scala
@@ -1,8 +1,39 @@
 package com.gu.contentapi
 
 import java.util.Properties
-import com.amazonaws.regions.{ Regions, Region }
+
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.s3.AmazonS3Client
 
+import scala.util.Try
 
-class Config(val context: Context) {}
+class Config(val context: Context) {
+  protected val s3Client: AmazonS3Client = new AmazonS3Client()
+
+  val isProd = Try(context.getFunctionName.toLowerCase.contains("-prod")).getOrElse(false)
+  private val stage = if (isProd) "PROD" else "CODE"
+  private val config = loadConfig()
+
+  val capiUrl = getConfigItem("capi.url")
+  val capiKey = getConfigItem("capi.key")
+
+  val ophanHost = getConfigItem("ophan.host")
+  val ophanKey = getConfigItem("ophan.key")
+
+  val kinesisName = getConfigItem("kinesis.name")
+
+  private def loadConfig() = {
+    val bucketName = "content-api-config"
+    val configFileKey = s"most-viewed-video-uploader/$stage/config.properties"
+    val configInputStream = s3Client.getObject(bucketName, configFileKey).getObjectContent
+    val configFile: Properties = new Properties()
+    Try(configFile.load(configInputStream)) orElse sys.error("Could not load config file from s3. This lambda will not run.")
+    configFile
+  }
+
+  private def getConfigItem(itemName: String): String = {
+    Option(config.getProperty(itemName)) getOrElse sys.error(s"'$itemName' property is missing.")
+  }
+
+}

--- a/src/main/scala/com/gu/contentapi/DevMain.scala
+++ b/src/main/scala/com/gu/contentapi/DevMain.scala
@@ -10,9 +10,6 @@ object DevMain extends App {
 
   val fakeScheduledEvent = new util.HashMap[String, Object]()
 
-  val start = System.nanoTime()
   new Lambda().handleRequest(fakeScheduledEvent, null)
-  val end = System.nanoTime()
-  Console.err.println(s"Time taken: ${Duration.fromNanos(end - start).toMillis} ms")
 
 }

--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -1,21 +1,50 @@
 package com.gu.contentapi
 
 import java.util.{ Map => JMap }
+import cats.data.Xor
+import cats.data.Xor._
 import com.amazonaws.services.lambda.runtime.{ RequestHandler, Context }
-import com.gu.contentapi.services.{Http, ContentApi}
-import scala.concurrent.Future
+import com.gu.contentapi.mostviewedvideo.model.v1._
+import com.gu.contentapi.mostviewedvideo.{ CustomError, OphanStore }
+import com.gu.contentapi.services.{ Kinesis, ContentApi }
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class Lambda
-    extends RequestHandler[JMap[String, Object], Unit] {
+    extends RequestHandler[JMap[String, Object], Unit]
+    with Kinesis
+    with OphanStore {
 
   override def handleRequest(event: JMap[String, Object], context: Context): Unit = {
+    val config = new Config(context)
 
-    implicit val config = new Config(context)
+    val capi = new ContentApi(config.capiUrl, config.capiKey)
 
-    println("The uploading of most viewed video has started")
+    def onOphanResponse(mostViewedContainers: Xor[CustomError, List[MostViewedVideoContainer]]): Unit = {
+      mostViewedContainers match {
+        case Left(error) => println(error.toString)
+        case Right(containers) => containers.foreach(publish(_, config) map onKinesisResponse)
+      }
+    }
+    def onKinesisResponse(kinesisResponse: Xor[CustomError, String]): Unit = {
+      println(kinesisResponse.fold(
+        { error => error.toString },
+        { id => s"Successfully sent most-viewed videos for $id" }
+      ))
+    }
 
+    val futureEditionIds = capi.getResponse(capi.editions).map(_.results.map(_.id))
+    for {
+      editionIds <- futureEditionIds
+    } yield {
 
-    println("The uploading of most viewed video has started.")
+      editionIds map { editionId =>
+
+        getMostViewedVideoBySection(Some(editionId), config) map onOphanResponse
+
+        getMostViewedVideoOverall(Some(editionId), config) map onOphanResponse
+      }
+    }
+
+    getMostViewedVideoBySection(None, config) map onOphanResponse
   }
-
 }

--- a/src/main/scala/com/gu/contentapi/models/MostViewedVideo.scala
+++ b/src/main/scala/com/gu/contentapi/models/MostViewedVideo.scala
@@ -1,5 +1,4 @@
 package com.gu.contentapi.models
 
-
-case class MostViewedVideo(id: String, count: Int, paths: List[String])
-case class MostViewedVideoContainer(id: String, content: List[MostViewedVideo])
+case class MostViewedVideo(id: String, count: Int)
+case class MostViewedVideoContainer(id: String, videos: List[MostViewedVideo])

--- a/src/main/scala/com/gu/contentapi/mostviewedvideo/CustomError.scala
+++ b/src/main/scala/com/gu/contentapi/mostviewedvideo/CustomError.scala
@@ -1,0 +1,5 @@
+package com.gu.contentapi.mostviewedvideo
+
+case class CustomError(message: String) {
+  override def toString = message
+}

--- a/src/main/scala/com/gu/contentapi/mostviewedvideo/OphanStore.scala
+++ b/src/main/scala/com/gu/contentapi/mostviewedvideo/OphanStore.scala
@@ -1,0 +1,114 @@
+package com.gu.contentapi.mostviewedvideo
+
+import java.io.IOException
+
+import cats.data.Xor
+import cats.data.Xor._
+import com.gu.contentapi.Config
+import com.gu.contentapi.services.Http
+import com.gu.contentapi.mostviewedvideo.model.v1.{ MostViewedVideo => MostViewedVideoThrift, MostViewedVideoContainer => MostViewedVideoContainerThrift }
+import com.gu.contentapi.models.{ MostViewedVideo => MostViewedVideoModel, MostViewedVideoContainer => MostViewedVideoContainerModel }
+import com.squareup.okhttp.{ Response, Callback, Request }
+import io.circe.parser._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ Promise, Future }
+
+trait OphanStore extends Http {
+  import OphanStore._
+
+  protected def getMostViewedVideoOverall(edition: Option[String], config: Config): Future[Xor[CustomError, List[MostViewedVideoContainerThrift]]] = {
+    val url = s"${config.ophanHost}/api/video/mostviewed?${buildCountryQuery(edition)}apiKey=${config.ophanKey}"
+    requestMostViewed(url, edition, config) map { json =>
+      json.flatMap(extractMostViewedVideoOverall(_, edition))
+    }
+  }
+
+  protected def getMostViewedVideoBySection(edition: Option[String], config: Config): Future[Xor[CustomError, List[MostViewedVideoContainerThrift]]] = {
+    val url = s"${config.ophanHost}/api/video/mostviewed/sections?${buildCountryQuery(edition)}apiKey=${config.ophanKey}"
+    requestMostViewed(url, edition, config) map { json =>
+      json.flatMap(extractMostViewedVideoBySection(_, edition))
+    }
+  }
+
+  private[this] def requestMostViewed(url: String, edition: Option[String], config: Config): Future[Xor[CustomError, String]] = {
+    val request = new Request.Builder().url(url).build
+    val promise = Promise[Xor[CustomError, String]]()
+
+    httpClient.newCall(request).enqueue(new Callback {
+      override def onFailure(request: Request, e: IOException): Unit =
+        promise.success(left(CustomError(s"Failed to send request to Ophan for $url: ${e.getStackTrace}")))
+
+      override def onResponse(response: Response) = {
+        if (response.isSuccessful) promise.success(right(response.body.string))
+        else promise.success(left(CustomError(s"Bad response from Ophan for $url: ${response.code}")))
+      }
+    })
+
+    promise.future
+  }
+
+  private[this] def buildCountryQuery(edition: Option[String]) = {
+    edition match {
+      case Some(ed) => s"country=${capiEditionToOphanCountry(ed)}&"
+      case None => ""
+    }
+  }
+  private[this] def capiEditionToOphanCountry(capiEdition: String) = {
+    capiEdition match {
+      case "uk" => "gb"
+      case other => other
+    }
+  }
+}
+
+object OphanStore {
+
+  def extractMostViewedVideoOverall(json: String, edition: Option[String]): Xor[CustomError, List[MostViewedVideoContainerThrift]] =
+    decodeOverallJson(json, edition) flatMap (containers => right(containers map mostViewedVideoContainerToThrift))
+
+  def extractMostViewedVideoBySection(json: String, edition: Option[String]): Xor[CustomError, List[MostViewedVideoContainerThrift]] =
+    decodeSectionsJson(json, edition) flatMap (containers => right(containers map mostViewedVideoContainerToThrift))
+
+  /**
+   * Unfortunately, circe cannot easily decode a json string to a thrift object (https://github.com/travisbrown/circe/issues/208).
+   * The simplest solution is to decode to intermediary case classes, then construct the thrift objects from these.
+   */
+  private[this] def decodeOverallJson(json: String, edition: Option[String]): Xor[CustomError, List[MostViewedVideoContainerModel]] = {
+    import io.circe.generic.auto._
+    decode[List[MostViewedVideoModel]](json).fold(
+      { error => left(CustomError(error.getMessage)) },
+      { overallVideos => right(List(MostViewedVideoContainerModel(buildId(edition, section = "overall"), overallVideos))) }
+    )
+  }
+  private[this] def decodeSectionsJson(json: String, edition: Option[String]): Xor[CustomError, List[MostViewedVideoContainerModel]] = {
+    import io.circe.generic.auto._
+    decode[Map[String, List[MostViewedVideoModel]]](json).fold(
+      { error => left(CustomError(error.getMessage)) },
+      { sections =>
+        {
+          val containers = sections map { sectionData =>
+            val sectionId = sectionData._1
+            val videos = sectionData._2
+            MostViewedVideoContainerModel(buildId(edition, sectionId), videos)
+          }
+          right(containers.toList)
+        }
+      }
+    )
+  }
+  private[this] def mostViewedVideoToThrift(mostViewedVideo: MostViewedVideoModel): MostViewedVideoThrift =
+    MostViewedVideoThrift(id = mostViewedVideo.id, count = mostViewedVideo.count)
+
+  private[this] def mostViewedVideoContainerToThrift(mostViewedVideoContainer: MostViewedVideoContainerModel): MostViewedVideoContainerThrift = {
+    MostViewedVideoContainerThrift(
+      id = mostViewedVideoContainer.id,
+      videos = mostViewedVideoContainer.videos.map(mostViewedVideoToThrift)
+    )
+  }
+
+  private[this] def buildId(edition: Option[String], section: String): String = {
+    Seq(edition, Some(section)).flatten.mkString("/")
+  }
+
+}

--- a/src/main/scala/com/gu/contentapi/services/Http.scala
+++ b/src/main/scala/com/gu/contentapi/services/Http.scala
@@ -2,6 +2,6 @@ package com.gu.contentapi.services
 
 import com.squareup.okhttp.OkHttpClient
 
-object Http {
+trait Http {
   lazy val httpClient: OkHttpClient = new OkHttpClient()
 }

--- a/src/main/scala/com/gu/contentapi/services/Kinesis.scala
+++ b/src/main/scala/com/gu/contentapi/services/Kinesis.scala
@@ -1,14 +1,51 @@
 package com.gu.contentapi.services
 
+import java.nio.ByteBuffer
+
+import cats.data.Xor
+import cats.data.Xor._
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.regions.{ Region, Regions }
 import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient
+import com.amazonaws.services.kinesis.model.{ PutRecordsResult, PutRecordsRequestEntry, PutRecordsRequest }
+import com.gu.contentapi.Config
+import com.gu.contentapi.mostviewedvideo.model.v1._
+import com.gu.contentapi.mostviewedvideo.CustomError
+import com.gu.thrift.serializer.ThriftSerializer
 
-trait Kinesis {
+import scala.concurrent.{ Future, Promise }
 
-  lazy val kinesisClient: AmazonKinesisAsyncClient = {
-    val kinesisClient = new AmazonKinesisAsyncClient()
+trait Kinesis extends ThriftSerializer {
+
+  private lazy val kinesisClient: AmazonKinesisAsyncClient = {
+    val kinesisClient = new AmazonKinesisAsyncClient(new ProfileCredentialsProvider("capi"))
     kinesisClient.setRegion(Region.getRegion(Regions.EU_WEST_1))
     kinesisClient
 
   }
+
+  def publish(data: MostViewedVideoContainer, config: Config): Future[Xor[CustomError, String]] = {
+
+    val record = new PutRecordsRequestEntry()
+      .withPartitionKey(data.id)
+      .withData(ByteBuffer.wrap(serializeToBytes(data)))
+
+    val request = new PutRecordsRequest()
+      .withStreamName(config.kinesisName)
+      .withRecords(record)
+
+    val promise = Promise[Xor[CustomError, String]]()
+
+    kinesisClient.putRecordsAsync(request, new AsyncHandler[PutRecordsRequest, PutRecordsResult] {
+      override def onError(exception: Exception): Unit =
+        promise.success(left(CustomError(s"Failed to publish most-viewed videos for: ${data.id}. Failed with error: ${exception.getStackTrace}")))
+
+      override def onSuccess(request: PutRecordsRequest, result: PutRecordsResult): Unit =
+        promise.success(right(data.id))
+    })
+
+    promise.future
+  }
+
 }

--- a/src/main/thrift/mostviewedvideo/mostviewedvideo.thrift
+++ b/src/main/thrift/mostviewedvideo/mostviewedvideo.thrift
@@ -1,0 +1,16 @@
+namespace scala com.gu.contentapi.mostviewedvideo.model.v1
+
+struct MostViewedVideo {
+
+    1: required string id;
+
+    2: required i32 count;
+}
+
+struct MostViewedVideoContainer {
+
+    1: required string id;
+
+    2: required list<MostViewedVideo> videos;
+
+}

--- a/src/test/resources/most-viewed-video-overall.json
+++ b/src/test/resources/most-viewed-video-overall.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "gu-video-56ed4a37e4b0304172354aab",
+    "count": 126,
+    "paths": [
+      "/world/2016/mar/19/istanbul-hit-by-deadly-bomb-attack",
+      "/international",
+      "/world/video/2016/mar/19/istanbul-reels-after-suicide-bombing-video",
+      "/world/turkey"
+    ]
+  },
+  {
+    "id": "gu-video-56ed24c4e4b0d5bc16af57dd",
+    "count": 61,
+    "paths": [
+      "/world/2016/mar/19/passenger-jet-crashes-on-landing-in-russian-city-of-rostov-on-don",
+      "/world/video/2016/mar/19/flydubai-air-crash-kills-62-in-russia-video-report"
+    ]
+  }
+]

--- a/src/test/resources/most-viewed-video-sections.json
+++ b/src/test/resources/most-viewed-video-sections.json
@@ -1,0 +1,22 @@
+{
+  "world": [
+    {
+      "id": "gu-video-56e99589e4b06837afd3e2d7",
+      "count": 686
+    },
+    {
+      "id": "gu-video-56eb7663e4b0a5327f1d183e",
+      "count": 308
+    }
+  ],
+  "us-news": [
+    {
+      "id": "gu-video-56ebbfcde4b0ba41c3b4a85e",
+      "count": 257
+    },
+    {
+      "id": "gu-video-56e976d1e4b06837afd3e260",
+      "count": 223
+    }
+  ]
+}

--- a/src/test/scala/com/gu/contentapi/ExtractMostViewedVideoTest.scala
+++ b/src/test/scala/com/gu/contentapi/ExtractMostViewedVideoTest.scala
@@ -11,7 +11,7 @@ class ExtractMostViewedVideoTest extends FlatSpec with Matchers {
   it should "extract overall most-viewed videos" in {
     val json = loadFileFromClasspath("most-viewed-video-overall.json")
     val expected = List(MostViewedVideoContainer(
-      id = "us/overall",
+      id = "us",
       videos = List(
         MostViewedVideo(id = "gu-video-56ed4a37e4b0304172354aab", count = 126),
         MostViewedVideo(id = "gu-video-56ed24c4e4b0d5bc16af57dd", count = 61)

--- a/src/test/scala/com/gu/contentapi/ExtractMostViewedVideoTest.scala
+++ b/src/test/scala/com/gu/contentapi/ExtractMostViewedVideoTest.scala
@@ -1,0 +1,45 @@
+import java.nio.file.{ Files, Paths }
+
+import com.gu.contentapi.mostviewedvideo.model.v1._
+import com.gu.contentapi.mostviewedvideo.OphanStore
+import org.scalatest.{ Matchers, FlatSpec }
+
+class ExtractMostViewedVideoTest extends FlatSpec with Matchers {
+
+  behavior of "most-viewed video extraction"
+
+  it should "extract overall most-viewed videos" in {
+    val json = loadFileFromClasspath("most-viewed-video-overall.json")
+    val expected = List(MostViewedVideoContainer(
+      id = "us/overall",
+      videos = List(
+        MostViewedVideo(id = "gu-video-56ed4a37e4b0304172354aab", count = 126),
+        MostViewedVideo(id = "gu-video-56ed24c4e4b0d5bc16af57dd", count = 61)
+      )
+    ))
+    val overall = OphanStore.extractMostViewedVideoOverall(json, Some("us")).toOption
+    overall should be(Some(expected))
+  }
+
+  it should "extract most-viewed videos by section" in {
+    val json = loadFileFromClasspath("most-viewed-video-sections.json")
+    val expected = List(
+      MostViewedVideoContainer(id = "world", videos = List(
+        MostViewedVideo("gu-video-56e99589e4b06837afd3e2d7", 686),
+        MostViewedVideo("gu-video-56eb7663e4b0a5327f1d183e", 308))
+      ),
+      MostViewedVideoContainer(id = "us-news", videos = List(
+        MostViewedVideo("gu-video-56ebbfcde4b0ba41c3b4a85e", 257),
+        MostViewedVideo("gu-video-56e976d1e4b06837afd3e260", 223)
+      ))
+    )
+    val sections = OphanStore.extractMostViewedVideoBySection(json, None).toOption
+    sections should be(Some(expected))
+  }
+
+  def loadFileFromClasspath(path: String): String = {
+    val uri = Paths.get(getClass.getClassLoader.getResource(path).toURI)
+    val bytes = Files.readAllBytes(uri)
+    new String(bytes, "UTF-8")
+  }
+}


### PR DESCRIPTION
Lambda requests most-viewed video lists from Ophan for all sections and editions.
Publishes these lists to kinesis (for Porter)

It uses two endpoints on Ophan:
1. /api/video/mostviewed - for overall most-viewed
2. /api/video/mostviewed/sections - for most-viewed by each section

