### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/content-platforms


### PR DESCRIPTION
This PR adds a CODEOWNERS file assigning the repository to @guardian/content-platforms. This is primarily to keep track of which repositories our team maintains.

GitHub will also automatically add this team as a reviewer if a PR is made on this repo.