### PR TITLE
Updates the Ophan api requests to use apiKey -> api-key

### DIFF
--- a/src/main/scala/com/gu/contentapi/mostviewedvideo/OphanStore.scala
+++ b/src/main/scala/com/gu/contentapi/mostviewedvideo/OphanStore.scala
@@ -31,7 +31,7 @@ trait OphanStore extends Http {
   }
 
   private[this] def buildUrl(path: String, edition: Option[String], config: Config) =
-    s"${config.ophanHost}$path?${buildCountryQuery(edition)}mins=${config.ophanMinutes}&apiKey=${config.ophanKey}"
+    s"${config.ophanHost}$path?${buildCountryQuery(edition)}mins=${config.ophanMinutes}&api-key=${config.ophanKey}"
 
   private[this] def buildCountryQuery(edition: Option[String]) = {
     edition match {


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR [continues the work](https://github.com/guardian/content-api/pull/2700) to add consistent API keys to consumers of the Ophan API. In this case we are seeing the requests including the API key, but the query param key doesn't match the correct format. 

This PR updates the query param key from `apiKey -> api-key`.

<img width="603" alt="image" src="https://user-images.githubusercontent.com/4633246/194871812-2f665d23-2410-4372-99ce-5f2e00a9ba16.png">


## How to test

We can see these [requests coming into](https://logs.gutools.co.uk/s/ophan/goto/ab88a630-42fa-11ed-9e3f-fd593ccbac21) Ophan, after this PR the logs should drop off.

## How can we measure success?

Ophan API consumers use an API key in the correct format.
