### PR TITLE
Add a README. It's the least I could do.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+## Deploying
+
+This project isn't deployable by any of our usual routes at this time, so when your changes are merged into the main 
+branch, check that out locally.
+
+You'll need some credentials loaded into your console under the capi profile. Get those from Janus.
+
+You'll find an `update-lambda.sh` script in the project's root directory. Running this will run the build in sbt and 
+upload the resulting .jar file to AWS.
+
+For example, run
+
+`$ ./update-lambda.sh PROD`
+
+which, if successful, and after a brief delay after packaging, will output something resembling
+
+```
+[info] Packaging /path/to/your/local/most-viewed-video-uploader/target/scala-2.12/most-viewed-video-uploader-assembly-0.1-SNAPSHOT.jar ...
+[info] Done packaging.
+[success] Total time: 12 s, completed 10-Oct-2022 16:32:41
+{
+    "FunctionName": "most-viewed-video-uploader-PROD",
+    .
+    .
+    .
+}
+```
+
+At this point just confirm that all is well by checking the last updated details of the function in the AWS console
+and keep an eye on logs for signs of problems. You can also query the ophan logs for evidence of the requests this
+lambda makes e.g. search for ophan logs with "/api/video/mostviewed" in the message, and for this application's 
+ophan API key.


### PR DESCRIPTION
## What does this change?
See that `README.md`? Let's put something in there.


## How to test

Find the `README.md`

## How can we measure success?

Do you know how to build and deploy this project? Success!

## Have we considered potential risks?

Yes. There aren't any associated with adding a `README.md`

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A (it's a `README.md`)

**There are still several things we need to do to this**, including updating SBT versions, creating a build and deployment strategy and migrating `master` to `main`. But right now, this is _just_ the README to explain how it is currently deployed. The other things will be in follow-up PR(s).

