### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,6 +15,6 @@ jobs:
       SKIP_NODE: true
       
       
-      JAVA_VERSION: 8
+      JAVA_VERSION: 11
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,40 +1,43 @@
 import sbt._
 import Keys._
 
-import com.typesafe.sbt.SbtScalariform.scalariformSettings
-
 val root = Project("most-viewed-video-uploader", file("."))
   .settings(
     scalacOptions += "-deprecation",
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-      "com.amazonaws" % "aws-java-sdk-s3" % "1.11.313",
-      "com.amazonaws" % "aws-java-sdk-kinesis" % "1.11.313",
-      "com.squareup.okhttp3" % "okhttp" % "3.10.0",
-      "com.gu" %% "content-api-client-default" % "12.0",
-      "io.circe" %% "circe-generic" % "0.9.3",
-      "io.circe" %% "circe-parser" % "0.9.3",
-      "org.apache.thrift" % "libthrift" % "0.9.2",
-      "com.twitter" %% "scrooge-core" % "3.20.0",
-      "com.gu" %% "thrift-serializer" % "2.1.0",
-      "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+      "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
+      "com.amazonaws" % "aws-java-sdk-s3" % "1.12.429",
+      "com.amazonaws" % "aws-java-sdk-kinesis" % "1.12.429",
+      "com.squareup.okhttp3" % "okhttp" % "4.10.0",
+      "com.gu" %% "content-api-client-default" % "19.2.1",
+      "io.circe" %% "circe-generic" % "0.14.5",
+      "io.circe" %% "circe-parser" % "0.14.5",
+      "org.apache.thrift" % "libthrift" % "0.18.1",
+      "com.twitter" %% "scrooge-core" % "22.12.0",
+      "com.gu" %% "thrift-serializer" % "4.0.2",
+      "org.scalatest" %% "scalatest" % "3.2.15" % "test"
     )
   )
   .settings(basicSettings)
   .settings(
     scalariformAutoformat := true,
-    assemblyMergeStrategy in assembly := {
+    assembly / assemblyMergeStrategy   := {
       case PathList("com", "gu", "storypackage", _*) => MergeStrategy.first
       case "shared.thrift"                           => MergeStrategy.first
       case x => 
-        val oldStrategy = (assemblyMergeStrategy in assembly).value
+        val oldStrategy = (assembly / assemblyMergeStrategy).value
         oldStrategy(x)
     }
   )
 
+dependencyOverrides ++=  Seq(
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2"
+)
+
+
 lazy val basicSettings = Seq(
   organization  := "com.gu",
   description   := "AWS Lambda for uploading most viewed video data to CAPI.",
-  scalaVersion  := "2.12.5",
+  scalaVersion  := "2.13.0",
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 resolvers += Resolver.bintrayIvyRepo("twittercsl", "sbt-plugins")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "4.20.0")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.12.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 

--- a/src/test/scala/com/gu/contentapi/ExtractMostViewedVideoTest.scala
+++ b/src/test/scala/com/gu/contentapi/ExtractMostViewedVideoTest.scala
@@ -2,9 +2,10 @@ import java.nio.file.{ Files, Paths }
 
 import com.gu.contentapi.mostviewedvideo.model.v1._
 import com.gu.contentapi.mostviewedvideo.OphanStore
-import org.scalatest.{ Matchers, FlatSpec }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ExtractMostViewedVideoTest extends FlatSpec with Matchers {
+class ExtractMostViewedVideoTest extends AnyFlatSpec with Matchers {
 
   behavior of "most-viewed video extraction"
 


### PR DESCRIPTION
## What does this change?

Bumps dependencies to bring down Snyk vulnerabilities.

Snapshot here: https://app.snyk.io/org/guardian-people/project/3076e041-a20d-46b4-a1b4-7357f30256ab/history/29f7ae3c-fa55-44d8-8a17-6767632bda80


## How to test
Tests pass locally. Merge -> Checkout locally -> Deploy -> Monitor

