### PR TITLE
Fix snyk vulns

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,9 @@ val root = Project("most-viewed-video-uploader", file("."))
     assembly / assemblyMergeStrategy   := {
       case PathList("com", "gu", "storypackage", _*) => MergeStrategy.first
       case "shared.thrift"                           => MergeStrategy.first
+      case "module-info.class" => MergeStrategy.first
+      case PathList("META-INF", "versions", "9", "module-info.class") => MergeStrategy.first
+      case "BUILD" => MergeStrategy.first
       case x => 
         val oldStrategy = (assembly / assemblyMergeStrategy).value
         oldStrategy(x)

--- a/update-lambda.sh
+++ b/update-lambda.sh
@@ -12,7 +12,7 @@ my_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 sbt assembly
 
-jar_file=$(echo $my_dir/target/scala-2.12/most-viewed-video-uploader*.jar)
+jar_file=$(echo $my_dir/target/scala-2.13/most-viewed-video-uploader*.jar)
 
 aws lambda update-function-code \
   --function-name most-viewed-video-uploader-$STAGE \


### PR DESCRIPTION
Bumps dependencies to bring down Snyk vulnerabilities. We had to manually upload the .jar to S3 as it was too big for the deployment script to upload. We need to fix that - but for now, this PR makes the changes on main consistent with those deployed to PROD.

## How to test

Deployed and tested in PROD.

## How can we measure success?

No more High Snyk vulns + no errors in logs

