### PR TITLE
Update to actions-riff-raff@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Build and upload
 
 on:
   push:
-    branches: [ "*" ]
+    branches: ["*"]
   pull_request:
-    branches: [ "main" ]
-  workflow_dispatch: { }
+    branches: ["main"]
+  workflow_dispatch: {}
 
 jobs:
   build:
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: cdk/package-lock.json
 
       - run: npm ci
@@ -66,6 +66,6 @@ jobs:
               - target/scala-2.13/most-viewed-video-uploader.jar
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()  #runs even if there is a test failure
+        if: always() #runs even if there is a test failure
         with:
           files: junit/*.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,23 +46,18 @@ jobs:
           java-version: 11
           cache: sbt
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          role-session-name: content-api-most-viewed-video-uploader-build
-
       - name: Build and test
         env:
           SBT_JUNIT_OUTPUT: ./junit
           JAVA_OPTS: -Dsbt.log.noformat=true
         run: |
           sbt 'test;assembly'
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v4
         with:
           configPath: riff-raff.yaml
           projectName: Content Platforms::Most Viewed Video Uploader
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           contentDirectories: |
             cloudformation:
               - cdk/cdk.out/MostViewedVideoUploader-PROD.template.json


### PR DESCRIPTION
Saw a recent email from DevX about upgrading, figured I’d do it quickly. Version 4 means we can get rid of the AWS credentials step and leaves us less vulnerable to credentials access by malicious dependencies

See [the release notes for version 4](https://github.com/guardian/actions-riff-raff/releases/tag/v4) and [those for version 3](https://github.com/guardian/actions-riff-raff/releases/tag/v3.0.0) (the latter necessary because we’re coming from version 2.)