### PR TITLE
Bump dependencies and patch up a couple of deprecations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
             most-viewed-video-uploader:
               - target/scala-2.13/most-viewed-video-uploader.jar
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always() #runs even if there is a test failure
         with:
           files: junit/*.xml

--- a/README.md
+++ b/README.md
@@ -1,36 +1,16 @@
 ## Deploying
 
-This project isn't deployable by any of our usual routes at this time, so when your changes are merged into the main 
-branch, check that out locally.
+This project is built and uploaded via Github Actions and deployed using RiffRaff's continuous deployment configuration.
 
-You'll need some credentials loaded into your console under the capi profile. Get those from Janus.
+If you need to manually run or re-run a build you can run the `Build and upload` action. 
+If this is done on the `main` branch, RiffRaff should pick it up and deploy it.
 
-You'll find an `update-lambda.sh` script in the project's root directory. Running this will run the build in sbt and 
-upload the resulting .jar file to AWS.
+After merging main and the deploy going out, just confirm that all is well by checking the last updated details 
+of the function in the AWS console and keep an eye on logs for signs of problems. 
+You can also query the ophan logs for evidence of the requests this lambda makes e.g. search for ophan 
+logs with "/api/video/mostviewed" in the message, and for this application's ophan API key.
 
-For example, run
+Note that the run frequency is once per hour, so you may need to trigger a test run of the lambda after a deployment.
 
-`$ ./update-lambda.sh PROD`
+There is no CODE environment here. 
 
-which, if successful, and after a brief delay after packaging, will output something resembling
-
-```
-[info] Packaging /path/to/your/local/most-viewed-video-uploader/target/scala-2.12/most-viewed-video-uploader-assembly-0.1-SNAPSHOT.jar ...
-[info] Done packaging.
-[success] Total time: 12 s, completed 10-Oct-2022 16:32:41
-{
-    "FunctionName": "most-viewed-video-uploader-PROD",
-    .
-    .
-    .
-}
-```
-## Temporarily
-
-After some major dependency bumps, the .jar file is too big for the `update-lambda` script to upload and therefore it needs to be manually uploaded to S3 and then picked up by lambda. 
-
-
-At this point just confirm that all is well by checking the last updated details of the function in the AWS console
-and keep an eye on logs for signs of problems. You can also query the ophan logs for evidence of the requests this
-lambda makes e.g. search for ophan logs with "/api/video/mostviewed" in the message, and for this application's 
-ophan API key.

--- a/build.sbt
+++ b/build.sbt
@@ -9,12 +9,12 @@ val root = Project("most-viewed-video-uploader", file("."))
       "com.amazonaws" % "aws-java-sdk-s3" % "1.12.641",
       "com.amazonaws" % "aws-java-sdk-kinesis" % "1.12.641",
       "com.squareup.okhttp3" % "okhttp" % "4.10.0",
-      "com.gu" %% "content-api-client-default" % "19.2.1",
+      "com.gu" %% "content-api-client-default" % "31.0.2",
       "io.circe" %% "circe-generic" % "0.14.5",
       "io.circe" %% "circe-parser" % "0.14.5",
       "org.apache.thrift" % "libthrift" % "0.18.1",
       "com.twitter" %% "scrooge-core" % "22.12.0",
-      "com.gu" %% "thrift-serializer" % "4.0.2",
+      "com.gu" %% "thrift-serializer" % "5.0.7",
       "org.scalatest" %% "scalatest" % "3.2.15" % "test"
     ),
     assemblyJarName := "most-viewed-video-uploader.jar"

--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,28 @@
 import sbt._
 import Keys._
 
+val awsSdkVersion = "1.12.641"
+val okHttpVersion = "4.12.0"
+val capiClientVersion = "31.0.2"
+val circeVersion = "0.14.5"
+val apacheThriftVersion = "0.20.0"
+val scroogeVersion = "22.12.0"
+val thriftSerializerVersion = "5.0.7"
+
 val root = Project("most-viewed-video-uploader", file("."))
   .settings(
     scalacOptions += "-deprecation",
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
-      "com.amazonaws" % "aws-java-sdk-s3" % "1.12.641",
-      "com.amazonaws" % "aws-java-sdk-kinesis" % "1.12.641",
-      "com.squareup.okhttp3" % "okhttp" % "4.10.0",
-      "com.gu" %% "content-api-client-default" % "31.0.2",
-      "io.circe" %% "circe-generic" % "0.14.5",
-      "io.circe" %% "circe-parser" % "0.14.5",
-      "org.apache.thrift" % "libthrift" % "0.18.1",
-      "com.twitter" %% "scrooge-core" % "22.12.0",
-      "com.gu" %% "thrift-serializer" % "5.0.7",
+      "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
+      "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
+      "com.gu" %% "content-api-client-default" % capiClientVersion,
+      "io.circe" %% "circe-generic" % circeVersion,
+      "io.circe" %% "circe-parser" % circeVersion,
+      "org.apache.thrift" % "libthrift" % apacheThriftVersion,
+      "com.twitter" %% "scrooge-core" % scroogeVersion,
+      "com.gu" %% "thrift-serializer" % thriftSerializerVersion,
       "org.scalatest" %% "scalatest" % "3.2.15" % "test"
     ),
     assemblyJarName := "most-viewed-video-uploader.jar"
@@ -27,6 +35,8 @@ val root = Project("most-viewed-video-uploader", file("."))
       case "shared.thrift"                           => MergeStrategy.first
       case "module-info.class" => MergeStrategy.first
       case PathList("META-INF", "versions", "9", "module-info.class") => MergeStrategy.first
+      case PathList("mozilla", "public-suffix-list.txt") => MergeStrategy.filterDistinctLines
+      case PathList("META-INF", "okio.kotlin_module") => MergeStrategy.preferProject
       case "BUILD" => MergeStrategy.first
       case x => 
         val oldStrategy = (assembly / assemblyMergeStrategy).value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,3 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.12.0")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.12.0")
+
+// The sbt-dependency-graph plugin isn't really needed but provides an in-browser view via dependencyBrowseTree.
+// The terminal-based version dependencyTree does the same thing and is bundled with SBT by default.
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/src/main/scala/com/gu/contentapi/Config.scala
+++ b/src/main/scala/com/gu/contentapi/Config.scala
@@ -1,14 +1,13 @@
 package com.gu.contentapi
 
 import java.util.Properties
-
 import com.amazonaws.services.lambda.runtime.Context
-import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.{ AmazonS3, AmazonS3ClientBuilder }
 
 import scala.util.Try
 
 class Config(val context: Context) {
-  protected val s3Client: AmazonS3Client = new AmazonS3Client()
+  protected val s3Client: AmazonS3 = AmazonS3ClientBuilder.defaultClient()
 
   val isProd = Try(context.getFunctionName.toLowerCase.contains("-prod")).getOrElse(false)
   private val stage = if (isProd) "PROD" else "CODE"

--- a/src/main/scala/com/gu/contentapi/services/Kinesis.scala
+++ b/src/main/scala/com/gu/contentapi/services/Kinesis.scala
@@ -1,10 +1,8 @@
 package com.gu.contentapi.services
 
-import java.nio.ByteBuffer
-
 import com.amazonaws.regions.{ Region, Regions }
-import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient
-import com.amazonaws.services.kinesis.model.{ PutRecordsResult, PutRecordsRequestEntry, PutRecordsRequest }
+import com.amazonaws.services.kinesis.{ AmazonKinesisAsync, AmazonKinesisAsyncClientBuilder }
+import com.amazonaws.services.kinesis.model.{ PutRecordsRequest, PutRecordsRequestEntry, PutRecordsResult }
 import com.gu.contentapi.Config
 import com.gu.contentapi.mostviewedvideo.model.v1._
 import com.gu.contentapi.mostviewedvideo.CustomError
@@ -12,18 +10,17 @@ import com.gu.thrift.serializer._
 
 trait Kinesis {
 
-  private lazy val kinesisClient: AmazonKinesisAsyncClient = {
-    val kinesisClient = new AmazonKinesisAsyncClient()
-    kinesisClient.setRegion(Region.getRegion(Regions.EU_WEST_1))
-    kinesisClient
-
+  private lazy val kinesisClient: AmazonKinesisAsync = {
+    AmazonKinesisAsyncClientBuilder.standard()
+      .withRegion(Region.getRegion(Regions.EU_WEST_1).getName)
+      .build()
   }
 
   def publish(data: MostViewedVideoContainer, config: Config): Either[CustomError, String] = {
 
     val record = new PutRecordsRequestEntry()
       .withPartitionKey(data.id)
-      .withData(ByteBuffer.wrap(ThriftSerializer.serializeToBytes(data, Some(GzipType), None)))
+      .withData(ThriftSerializer.serializeToBytes(data, Some(GzipType), None))
 
     val request = new PutRecordsRequest()
       .withStreamName(config.kinesisName)


### PR DESCRIPTION
## What does this change?

Primarily we're bringing in an updated version of our `thrift-serializer` dependency, and while doing that I noticed that there were some other dependencies that could be bumped so did those too.

I also took the opportunity to get rid of a couple of deprecated code warnings coming out of AWS, and those are perhaps the biggest risks here as we only have a PROD environment to test in.

There were a couple of MergeStrategy changes required for these dependency upgrades in order to make the build work.

The README was also very much out of date in relation to the build and deploy process, so I updated that.

## How to test

~~I'm probably going to try deploying this branch to PROD and possibly triggering it manually once I've got all the log tracking ready.~~

Deployed this branch to PROD. Saw that it started in response to the normal configured timed trigger, made requests to Ophan and resulted in indexing via Porter.

The number and types of requests and activities logged appear consistent with previous runs of the `main` branch.

## How can we measure success?

If we pull updates from Ophan and feed them to Porter... success!

## Have we considered potential risks?

If it doesn't work we can redeploy the most recent `main` build back while we figure it out.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A
