### PR TITLE
Run snyk workflow on main branch (not master)

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -3,7 +3,7 @@ name: Snyk
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - update-snyk-workflow-to-main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - update-snyk-workflow-to-main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this change?

Though the default branch on this repo is currently main, the snyk workflow has been only running on master. This means Snyk has not been tracking vulnerabilities for this repo. This PR corrects the workflow definition to run on main.

## How can we measure success?

- The app will update [in Snyk](https://app.snyk.io/org/guardian-capi/project/667ed462-1b94-421b-a681-4c9632af56c5) now
