### PR TITLE
Update jackson core to fix vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ val root = Project("most-viewed-video-uploader", file("."))
     }
   )
 
-Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit"))
+Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit"), "-o")
 
 lazy val basicSettings = Seq(
   organization  := "com.gu",

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,6 @@ Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.get
 lazy val basicSettings = Seq(
   organization  := "com.gu",
   description   := "AWS Lambda for uploading most viewed video data to CAPI.",
-  scalaVersion  := "2.13.0",
+  scalaVersion  := "2.13.14",
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,6 @@ val root = Project("most-viewed-video-uploader", file("."))
   )
   .settings(basicSettings)
   .settings(
-    scalariformAutoformat := true,
     assembly / assemblyMergeStrategy   := {
       case PathList("com", "gu", "storypackage", _*) => MergeStrategy.first
       case "shared.thrift"                           => MergeStrategy.first

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt._
 import Keys._
 
-val awsSdkVersion = "1.12.641"
+val awsSdkVersion = "1.12.771"
 val okHttpVersion = "4.12.0"
 val capiClientVersion = "31.0.2"
 val circeVersion = "0.14.5"
@@ -43,9 +43,6 @@ val root = Project("most-viewed-video-uploader", file("."))
     }
   )
 
-dependencyOverrides ++=  Seq(
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2"
-)
 Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit"))
 
 lazy val basicSettings = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.3
+sbt.version=1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.12.0")
 
-// The sbt-dependency-graph plugin isn't really needed but provides an in-browser view via dependencyBrowseTree.
-// The terminal-based version dependencyTree does the same thing and is bundled with SBT by default.
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+// The dependency tree plugin isn't really needed but provides an in-browser
+// view via dependencyTree and dependencyBrowseTree: it’s bundled with SBT by
+// default, and just needs enabling
+addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,6 @@ resolvers += Resolver.bintrayIvyRepo("twittercsl", "sbt-plugins")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
-
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.12.0")
 
 // The sbt-dependency-graph plugin isn't really needed but provides an in-browser view via dependencyBrowseTree.


### PR DESCRIPTION
## What does this change?

This PR updates our AWS dependency versions, in order to update the transitive dependencies on jackson-core and resolve a vulnerability reported by Snyk. I’ve also updated a few other things (sbt, scala, etc.) while here – can move those to a separate PR if needed!

Here are the commits involved:

### aca704d Remove scalariform

Scalariform is now unmaintained and hasn’t been updated in a long time. It starts to cause version conflicts with its dependency on old versions of scala-xml, so I’m removing it.

I’ll set up scalafmt in another commit/PR, to keep the current diff and change size smaller.

### c775ab0 Remove old sbt-dependency-graph plugin

dependencyBrowseTree is included versions of sbt after 1.4, so there’s no need for this plugin anymore.

### 465b56d Update version of sbt

1.7.3 is a bit old now, so while I’m here I might as well move us to a newer version. Also, this will be new enough for us to enable scala-steward on this repository, helping us keep on top of dependencies.

### a8bf88e Update scala version to latest 2.13

While I’m here I might as well update, plus I had a version conflict with the scala library (probably due to the sbt upgrade, I think). This scala version is also new enough for us to use scala-steward.

### c275565 Update AWS SDK version and remove jackson override

These newer AWS SDK libraries depend on a new enough version of jackson that they avoid the vulnerability I’m currently trying to fix, meaning we no longer need the dependency override.

### 3c54c87 Include scalatest output on stdout

When providing the -u flag, scalatest defaults to not showing test results for each test on stdout. Since some developers prefer the junit output and some prefer the stdout output, adding the -o flag (which restores the stdout output) accommodates both groups.

## How to test

There’s no CODE environment, so we’ll have to rely on the automated tests and checking everything looks ok in PROD post-merge. I have run `snyk test` locally and confirmed the vulnerability is fixed.

## How can we measure success?

- Snyk vulnerability is resolved
- Scala steward can be enabled

## Have we considered potential risks?

I’m updating a few things at once (sbt, scala), but it’s usually fine.