### PR TITLE
Add runtime dependency on logback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,8 @@ val root = Project("most-viewed-video-uploader", file("."))
       "org.apache.thrift" % "libthrift" % apacheThriftVersion,
       "com.twitter" %% "scrooge-core" % scroogeVersion,
       "com.gu" %% "thrift-serializer" % thriftSerializerVersion,
-      "org.scalatest" %% "scalatest" % "3.2.15" % "test"
+      "org.scalatest" %% "scalatest" % "3.2.15" % "test",
+      "ch.qos.logback" % "logback-classic" % "1.5.7" % Runtime,
     ),
     assemblyJarName := "most-viewed-video-uploader.jar"
   )


### PR DESCRIPTION
## What does this change?

Currently, when the lambda runs [there is an SLF4J warning about there being no providers configured](https://logs.gutools.co.uk/s/content-platforms/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2024-09-06T13:14:18.359Z',to:'2024-09-06T14:14:19.491Z'))&_a=(columns:!(level,message),filters:!(),index:b0be43a0-59d7-11e8-a75a-b7af20e8f748,interval:auto,query:(language:kuery,query:'app.keyword:%20%22most-viewed-video-uploader%22%20AND%20stage.keyword:%20%22PROD%22%20AND%20message:%20SLF4J'),sort:!(!('@timestamp',desc)))), explaining that it’s running in no-op mode. I believe if we add a runtime dependency on logback (which is an SLF4J provider), we’ll get log output from our dependencies using SLF4J.

## How to test

We don’t have a CODE environment for this app, so I’m going to deploy to PROD and execute the function there to test. If anything goes wrong I think the lambda will just crash and I can re-deploy main.

## How can we measure success?

Hopefully, our dependencies’ logs should appear!