### PR TITLE
Run GHA builds on pull_request (not push)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,11 @@
 name: Build and upload
 
 on:
-  push:
-    branches: ["*"]
   pull_request:
-    branches: ["main"]
-  workflow_dispatch: {}
+  push: # Do not rely on `push` for PR CI - see https://github.com/guardian/mobile-apps-api/pull/2760
+    branches:
+      - main # Optimal for GHA workflow caching - see https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build and upload
 
 on:
   pull_request:
+    branches:
+      - "*"
   push: # Do not rely on `push` for PR CI - see https://github.com/guardian/mobile-apps-api/pull/2760
     branches:
       - main # Optimal for GHA workflow caching - see https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache


### PR DESCRIPTION
## What does this change?

Currently, every commit pushed to a pull request causes two builds, which is unnecessary. Because using push can make pull request checks misleading (where checks failed on an earlier commit but succeed on the latest commit, even if the later commits have not fixed the problem that caused the failure on the earlier commit), I’m limiting push to the main branch.

https://github.com/guardian/mobile-apps-api/pull/2760 explains the problem as it was encountered on mobile-apps-api.

## How can we measure success?

- this PR should only have a pull_request build triggered on it, with no push build