### PR TITLE
Add setup-sbt to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,12 +41,7 @@ jobs:
         name: Build infrastructure definition from CDK
         working-directory: cdk
 
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: corretto
-          java-version: 11
-          cache: sbt
+      - uses: guardian/setup-scala@v1
 
       - name: Build and test
         env:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.25.9.1


### PR DESCRIPTION

## What does this change?

As we're so dependent on `sbt` and the `sbt launcher` hence we should provide this in our workflow so that external dependency wouldn't matter such as we had failed workflows on upgraded version of `ubuntu` recently because it has no `sbt` information in it.
So, to save us from these kind of issues we will provide our own `setup-sbt` as an action to resolve `sbt` easily.

## How to test

Raise this PR and observe running CI.

## How can we measure success?

Build should run as normal and no failing CI should be observed.

